### PR TITLE
Prevent console validator errors when no labels set for field view

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -61,8 +61,8 @@ export default {
 
         labelConfig(){
             return {
-                checked:  (this.field.show_true_label) ? this.trueLabel : null,
-                unchecked: (this.field.show_false_label) ? this.falseLabel : null,
+                checked:  (this.field.show_true_label) ? this.trueLabel : false,
+                unchecked: (this.field.show_false_label) ? this.falseLabel : false,
             }
         },
 


### PR DESCRIPTION
Hi,

Currently when this toggle is used in the form view WITHOUT the labels being specified it throws the following validation console error:

Ie, in the nova resource

```php
            Toggle::make('Active', 'is_active')
                ->required()
```

Produces:
```
[Vue warn]: Invalid prop: custom validator check failed for prop "labels".

found in

---> <ToggleButton>
       <DefaultField> at resources/js/components/Form/DefaultField.vue
         <FormNovaToggle>
           <Card> at resources/js/components/Card.vue
             <FormPanel> at resources/js/components/Form/Panel.vue
               <LoadingView> at resources/js/components/LoadingView.vue
                 <Update> at resources/js/views/Update.vue
                   <Root>
```



The source in vue-js-toggle-button shows that the label config must be an Object or a BOOLEAN

https://github.com/euvl/vue-js-toggle-button/blob/master/src/Button.vue#L92-L98
```js
labels: {
      type: [Boolean, Object],
      default: false,
      validator(value) {
        return typeof value === 'object'
          ? value.checked || value.unchecked
          : typeof value === 'boolean'
      }
```




In this projects `form-field` file, if the labels are not set, it sets NULL instead of BOOLEAN. When the validator tries to validate it, it gets the wrong type and throws the console log error.


This PR tries to fix that.